### PR TITLE
Fix crash if options is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var batchCompiler;
 module.exports = tsPlugin;
 
 function tsPlugin(options) {
+    options = options || {};
 
     settings = buildSettings(options);
     if (!settings.noResolve()) {


### PR DESCRIPTION
This fixes a case when `tsc` is called like `.pipe(tsc())` e.g. without
`options` argument at all. This caused a crash described in #3.

With this fix it is now allowed to use `tsc()` without `options` argument.
